### PR TITLE
Let Rails constantize the association's class

### DIFF
--- a/lib/rails/plantuml/generator/model_generator.rb
+++ b/lib/rails/plantuml/generator/model_generator.rb
@@ -37,7 +37,7 @@ module Rails
             associations.each do |association|
               next if association.options[:polymorphic]
               next if association.through_reflection
-              other = association.class_name.constantize
+              other = association.klass
 
               next unless class_relevant? other
 


### PR DESCRIPTION
This solves a problem where the former code would fail constantizing namespaced classes.

For example:
```ruby
module A
  class B < ApplicationRecord
    belongs_to :c
  end

  class C < ApplicationRecord; end
end
```

The old code would fail constantizing an inexistent class called "C", but the new code properly constantizes "A::C" even if the `belongs_to` association doesn't mention A.